### PR TITLE
backend: add in-memory cache with TTL and metrics

### DIFF
--- a/backend/env.js
+++ b/backend/env.js
@@ -1,0 +1,20 @@
+// Centralized environment loader
+// - Reads .env once via dotenv
+// - Exposes typed/configured constants for the app
+// - Single source of truth for defaults, validation, and future overrides
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '.env') });
+
+
+const cfg = {
+  PORT: Number(process.env.PORT) || 8000,
+  ALPHA_VANTAGE_KEY: process.env.ALPHA_VANTAGE_KEY,
+  NODE_ENV: process.env.NODE_ENV || 'development'
+};
+
+// TODO: enforce required vars in production
+// if (cfg.NODE_ENV === 'production' && !cfg.ALPHA_VANTAGE_KEY) {
+//   throw new Error('Missing ALPHA_VANTAGE_KEY env var');
+// }
+
+module.exports = cfg;

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,47 +1,56 @@
-require('dotenv').config();
+
+const { PORT, ALPHA_VANTAGE_KEY, NODE_ENV } = require('./env');
 const express = require('express');
 const cors = require('cors');
-const app = express();
-
-// Enable all CORS requests
-app.use(cors());
-const searchCache = new Map(); // key -> { expires: number, data: any }
-
 const axios = require('axios');
+const SimpleCache = require('./utils/cache');
+
+const app = express();
+app.use(cors());
+
+
+const searchCache = new SimpleCache(500);
+const stockCache = new SimpleCache(500);
+const apiKey = ALPHA_VANTAGE_KEY;
 
 app.get('/api/search/:symbol', async (req, res) => {
   const symbol = (req.params.symbol || '' ).trim();
-  const apiKey = process.env.ALPHA_VANTAGE_KEY;
   if (!apiKey) {
     return res.status(500).json({ error: 'Missing API key'});
   }
+    // TODO: strengthen validation (ticker regex ^[A-Z.-]{1,7}$ and normalize to upper-case)
+
+  if (!symbol || symbol.length < 1) {
+    return res.status(400).json({ error: 'Missing or invalid symbol' });
+  }
 
   try {
-
-    if (!symbol || symbol.length < 1) {
-      return res.status(400).json({ error: 'Missing or invalid symbol' });
-    }
     // 1) validate input (return 400 if missing/too short)
     // 2) check searchCache.get(key) and return cached.data if not expired
     const key = symbol.toLowerCase();
     const cached = searchCache.get(key);
-    if (cached && cached.expires > Date.now()) {
-      return res.json(cached.data);
+    if (cached) {
+      console.log('Returning cached search for:', symbol);
+      return res.json(cached);
     }
+
     const resp = await axios.get('https://www.alphavantage.co/query', {
         params: {
         function: 'SYMBOL_SEARCH',
         keywords: symbol,
         apikey: apiKey
+        
       }
-    }
-  );
+    });
+
+    //check for errors
+    // TODO: move API error normalization to a tiny helper (alphaErrorOf(resp.data))
 
   if (resp.data.Note || resp.data['Error Message'] || resp.data.Information) {
         return res.status(429).json({ error: resp.data.Note || resp.data['Error Message'] || resp.data.Information });
   }
     const ttL = 60 * 1000;
-    searchCache.set(key, { expires: Date.now() + ttL, data: resp.data });
+    searchCache.set(key, resp.data, ttL);
     return res.json(resp.data);
     // 4) if resp.data.Note / resp.data['Error Message'] -> res.status(429).json({ error: ... })
     // 5) cache and return resp.data (set TTL ~60s)
@@ -54,24 +63,41 @@ app.get('/api/search/:symbol', async (req, res) => {
 
 app.get('/api/stock/:symbol', async (req, res) => {
   const symbol = req.params.symbol;
-  const apiKey = process.env.ALPHA_VANTAGE_KEY;
   if (!apiKey) {
     console.error('ALPHA_VANTAGE_KEY not set in .env');
     return res.status(500).json({ error: 'Missing API key'} );
   }
 
   try {
+    const outputsize = req.query.outputsize === 'full' ? 'full' : 'compact';
+    //CHECK CACHE
+    const cacheKey = `${symbol}::${outputsize}`;
+    const cached = stockCache.get(cacheKey);
+    if (cached) {
+      console.log('Cache HIT for', cacheKey);
+      return res.json(cached);
+    }
+    console.log('Cache MISS for', cacheKey);
+    
+    // TODO: extract this external call into services/alphaVantageService.js later
+
     const response = await axios.get('https://www.alphavantage.co/query', {
       params: {
         function: 'TIME_SERIES_DAILY',
         symbol : symbol,
-        apikey: apiKey
+        apikey: apiKey,
+        outputsize: outputsize
       }
 
     }
   );
-  console.log('alpha response keys:', Object.keys(response.data || {}));
+    // TODO: handle Alpha Vantage rate-limit messages here like in search route
+
+  const ttl = outputsize === 'full' ? 24 * 60 * 60 * 1000 : 5 * 60 * 1000;
+  stockCache.set(cacheKey, response.data, ttl);
   res.json(response.data);
+
+  console.log('alpha response keys:', Object.keys(response.data || {}));
   } catch (error) {
     console.error('alpha fetch error:', error?.response?.data || error.message);
     res.status(500).json({ error: 'Error fetching stock data' });
@@ -79,11 +105,25 @@ app.get('/api/stock/:symbol', async (req, res) => {
 
 })
 
+app.get('/api/cache/stats', (req, res) => {
 
+  const stats = {
+    search: searchCache.getStats(),
+    stock: stockCache.getStats(),
+    timestamp: new Date().toISOString()
+  };
+
+  res.json(stats);
+
+})
 /*app.get('/stock/:ticker', (req, res) => {
   const ticker = req.params.ticker.toUpperCase();
   
   
 });*/
 
-app.listen(8000, () => console.log('Backend running on http://localhost:8000'));
+// TODO: add dev-only cache clear endpoint
+// app.post('/api/cache/clear', (req, res) => { const a=searchCache.getStats().size, b=stockCache.getStats().size; searchCache.clear(); stockCache.clear(); res.json({ cleared: { search:a, stock:b } }); });
+// TODO: add /healthz with dependency checks (e.g., AlphaVantage key present)
+
+app.listen(PORT, () => console.log(`Backend running on http://localhost:${PORT}`));

--- a/backend/utils/cache.js
+++ b/backend/utils/cache.js
@@ -1,0 +1,91 @@
+class SimpleCache {
+  /**
+   * @param {number} maxEntries - Maximum number of cache entries
+   */
+  constructor(maxEntries = 500) {
+    /** @type {Map<string, {data: any, expires: number}>} */
+    this.map = new Map();
+    /** @type {number} */
+    this.maxEntries = maxEntries;
+    this.hits = 0;        // read successfully
+    this.misses = 0;      //no entry found 
+    this.requests = 0;    //requests = hit + misses
+    this.puts = 0;        // times a value was updated/inserted ( set called)) 
+    this.evictions = 0;   // entries removed automatically ( capacity, expiration cleanup )
+  }
+
+  /**
+   * Get cached value
+   * @param {string} key 
+   * @returns {any|null}
+   */
+  get(key) {
+    this.requests++;
+    const entry = this.map.get(key);
+    if (!entry) {
+      this.misses++;
+      return null;
+    }
+
+    if (entry.expires && entry.expires <= Date.now()) {
+    this.map.delete(key);
+    this.evictions++;
+    this.misses++;
+    return null;
+    }
+
+    this.hits++;
+    return entry.data;
+  }
+
+  /**
+   * Set cache value with TTL
+   * @param {string} key 
+   * @param {any} data 
+   * @param {number} ttlMs - Time to live in milliseconds
+   */
+  set(key, data, ttlMs = 60 * 1000) {
+    // Simple LRU: delete oldest when full
+    if (this.map.size >= this.maxEntries) {
+      const firstKey = this.map.keys().next().value;
+      if (firstKey) {
+        this.map.delete(firstKey);
+        this.evictions++;
+      }
+    }
+    
+    this.map.set(key, {
+      data,
+      expires: Date.now() + ttlMs
+    });
+    this.puts++;
+  }
+
+  clear() {
+    this.map.clear();
+  }
+
+
+  /**
+   * returns simple cache stats
+   * @returns {{size:number, maxEntries:number, hits:number, misses:number, requests:number, hitRate:number}}
+   * 
+   */
+  getStats() {
+    const hits = this.hits || 0;
+    const misses = this.misses || 0;
+    const total = hits + misses;
+    const hitRate = (this.hits / (this.hits + this.misses ));
+        return { size: this.map ? this.map.size : 0 , 
+                maxEntries: this.maxEntries, 
+                hits, 
+                misses, 
+                requests: this.requests || 0, 
+                puts: this.puts || 0, 
+                evictions: this.evictions || 0, 
+                hitRate 
+              };
+  }
+}
+
+module.exports = SimpleCache;

--- a/backend/utils/cache.js
+++ b/backend/utils/cache.js
@@ -74,7 +74,6 @@ class SimpleCache {
   getStats() {
     const hits = this.hits || 0;
     const misses = this.misses || 0;
-    const total = hits + misses;
     const hitRate = (this.hits / (this.hits + this.misses ));
         return { size: this.map ? this.map.size : 0 , 
                 maxEntries: this.maxEntries, 

--- a/backend/utils/cache.js
+++ b/backend/utils/cache.js
@@ -28,10 +28,10 @@ class SimpleCache {
     }
 
     if (entry.expires && entry.expires <= Date.now()) {
-    this.map.delete(key);
-    this.evictions++;
-    this.misses++;
-    return null;
+      this.map.delete(key);
+      this.evictions++;
+      this.misses++;
+      return null;
     }
 
     this.hits++;

--- a/backend/utils/cache.js
+++ b/backend/utils/cache.js
@@ -8,7 +8,7 @@ class SimpleCache {
     /** @type {number} */
     this.maxEntries = maxEntries;
     this.hits = 0;        // read successfully
-    this.misses = 0;      //no entry found 
+    this.misses = 0;      // no entry found 
     this.requests = 0;    //requests = hit + misses
     this.puts = 0;        // times a value was updated/inserted ( set called)) 
     this.evictions = 0;   // entries removed automatically ( capacity, expiration cleanup )


### PR DESCRIPTION
Implement SimpleCache utility class with:
- TTL-based expiration and LRU eviction (500 max entries)
- Metrics tracking: hits, misses, requests, evictions, hit rate
- Cache stats endpoint at /api/cache/stats

Cache Alpha Vantage API responses:
- Search results: 60s TTL
- Stock data: 24h (full) / 5min (compact)

Centralizes env config in backend/env.js for PORT, ALPHA_VANTAGE_KEY, NODE_ENV.

In-memory cache resets on restart; ready for Redis migration when scaling.

Files: backend/index.js, backend/utils/cache.js, backend/env.js